### PR TITLE
Adding Swift WebAssembly Support

### DIFF
--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -1,0 +1,24 @@
+name: WebAssembly CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - '**'
+
+jobs:
+  test:
+    name: BezierKit WASM support
+    runs-on: ubuntu-latest
+    container: ghcr.io/swiftwasm/carton:0.16.0
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+
+      - name: Test WebAssembly
+        run: carton test

--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,8 @@ let package = Package(
         .target(name: "tree-sitter",
                 path: "tree-sitter/lib",
                 sources: ["src/lib.c"],
-                publicHeadersPath: "include"),
+                publicHeadersPath: "include",
+                cSettings: [.headerSearchPath("src/")]),
         .target(name: "SwiftTreeSitter", dependencies: ["tree-sitter"]),
         .testTarget(name: "SwiftTreeSitterTests", dependencies: ["SwiftTreeSitter"]),
     ]

--- a/Sources/SwiftTreeSitter/Language.swift
+++ b/Sources/SwiftTreeSitter/Language.swift
@@ -55,6 +55,7 @@ extension Language {
     }
 }
 
+#if !os(WASI)
 public extension Language {
     func query(contentsOf url: URL) throws -> Query {
         let data = try Data(contentsOf: url)
@@ -62,3 +63,4 @@ public extension Language {
         return try Query(language: self, data: data)
     }
 }
+#endif


### PR DESCRIPTION
## Description

This PR makes the project to be WASM-friendly.

You can find more information about `Swift WASM` [here](https://swiftwasm.org/)

The PR basically does:
- Force to use headers from the project instead of from the machine/OS.
- Disable not supported WASM functionality
- Adding specific CI for WASM

Cheers