### PR TITLE
Workaround to make it compile in WASM

### DIFF
--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -10,9 +10,9 @@ on:
 
 jobs:
   test:
-    name: BezierKit WASM support
+    name: WASM support
     runs-on: ubuntu-latest
-    container: ghcr.io/swiftwasm/carton:0.16.0
+    container: ghcr.io/swiftwasm/carton:0.17.0
 
     steps:
       - name: Checkout

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -20,5 +20,11 @@ jobs:
         with:
           submodules: recursive
 
+      # Work around to avoid this issue: https://github.com/ChimeHQ/SwiftTreeSitter/issues/8
+      # We are running wasm-opt -O before execute the test for avoiding maximum of locals
       - name: Test WebAssembly
-        run: carton test
+        run: |
+          swift build -c debug --product SwiftTreeSitterPackageTests -Xswiftc -color-diagnostics --triple wasm32-unknown-wasi
+          wasm-opt -O .build/wasm32-unknown-wasi/debug/SwiftTreeSitterPackageTests.wasm -o SwiftTreeSitterPackageTests.wasm
+          wasmer SwiftTreeSitterPackageTests.wasm
+


### PR DESCRIPTION
The generated code for `tree-sitter-swift` is that long that is making the WASM generation to exceed the local limits.
Using `wasm-opt -O` is improving the generated code avoiding the issue.

https://github.com/ChimeHQ/SwiftTreeSitter/issues/8

This is a workaround, I have already notified the `Swift WASM toolchain` guys to try to solve that issue.

Cheers