### PR TITLE
Add language support for finding resources

### DIFF
--- a/Sources/SwiftTreeSitter/Language.swift
+++ b/Sources/SwiftTreeSitter/Language.swift
@@ -23,8 +23,8 @@ public struct Language {
     ///   - language: The language to parse.
     ///   - languageName: The name of the language. This is used to attempt to find the embedded resource directory
     ///    for the language (which would contain files like highlights.scm).
-    public init(language: UnsafePointer<TSLanguage>, languageName: String) {
-        self.init(language: language, directoryProvider: Language.embeddedResourceProvider(named: languageName))
+    public init(language: UnsafePointer<TSLanguage>, name: String) {
+        self.init(language: language, directoryProvider: Language.embeddedResourceProvider(named: name))
     }
 }
 

--- a/Sources/SwiftTreeSitter/Language.swift
+++ b/Sources/SwiftTreeSitter/Language.swift
@@ -11,9 +11,23 @@ public struct Language {
     public var tsLanguage: UnsafePointer<TSLanguage>
     public var directoryProvider: DirectoryProvider?
 
+    /// Creates an instance.
+    /// - Parameters:
+    ///   - language: The language to parse.
+    ///   - directoryProvider: An optional closure which would return a `URL` that can be searched for resources
+    ///   used by the language (such as highlights.scm).
     public init(language: UnsafePointer<TSLanguage>, directoryProvider: DirectoryProvider? = nil) {
         self.tsLanguage = language
         self.directoryProvider = directoryProvider
+    }
+
+    /// Creates an instance.
+    /// - Parameters:
+    ///   - language: The language to parse.
+    ///   - languageName: The name of the language. This is used to attempt to find the embeeded resource directory
+    ///    for the language (which would contain files like highlights.scm).
+    public init(language: UnsafePointer<TSLanguage>, languageName: String) {
+        self.init(language: language, directoryProvider: embeddedResourceProvider(named: languageName))
     }
 }
 
@@ -78,7 +92,7 @@ extension Language: Equatable {
 /// in an app context vs an XCTest context.
 /// - Parameter resourceDirectory: The name of the directory or bundle to search for embedded within the main bundle.
 /// - Returns: If found, returns the directory provider closure.
-public func embeddedResourceProvider(named resourceDirectory: String) -> DirectoryProvider? {
+private func embeddedResourceProvider(named resourceDirectory: String) -> DirectoryProvider? {
     let fileManager = FileManager.default
     var bundle = Bundle.main
 

--- a/Sources/SwiftTreeSitter/Language.swift
+++ b/Sources/SwiftTreeSitter/Language.swift
@@ -1,21 +1,18 @@
 import Foundation
 import tree_sitter
 
-/// This is a closure whose output URL is to the directory which has the language `scm` files in its hierarchy. The
-/// ultimate search is recursive; if the resource files are embedded within hierarchy
-/// `Resources.bundle/Contents/Resources/queries`, giving the path to `Resources.bundle` will result in the files
-/// being found.
-public typealias DirectoryProvider = () -> URL
-
 public struct Language {
+    /// This is a closure whose output URL is to the directory which has the language `scm` files.
+    public typealias DirectoryProvider = () -> URL
+
     public var tsLanguage: UnsafePointer<TSLanguage>
     public var directoryProvider: DirectoryProvider?
 
     /// Creates an instance.
     /// - Parameters:
     ///   - language: The language to parse.
-    ///   - directoryProvider: An optional closure which would return a `URL` that can be searched for resources
-    ///   used by the language (such as highlights.scm).
+    ///   - directoryProvider: An optional closure which would return a directory `URL` to the container of the
+    ///   language's `scm` resources.
     public init(language: UnsafePointer<TSLanguage>, directoryProvider: DirectoryProvider? = nil) {
         self.tsLanguage = language
         self.directoryProvider = directoryProvider
@@ -24,10 +21,10 @@ public struct Language {
     /// Creates an instance.
     /// - Parameters:
     ///   - language: The language to parse.
-    ///   - languageName: The name of the language. This is used to attempt to find the embeeded resource directory
+    ///   - languageName: The name of the language. This is used to attempt to find the embedded resource directory
     ///    for the language (which would contain files like highlights.scm).
     public init(language: UnsafePointer<TSLanguage>, languageName: String) {
-        self.init(language: language, directoryProvider: embeddedResourceProvider(named: languageName))
+        self.init(language: language, directoryProvider: Language.embeddedResourceProvider(named: languageName))
     }
 }
 
@@ -83,33 +80,6 @@ extension Language: Equatable {
     }
 }
 
-/// For languages where the resources are embedded in the app's bundle, this function returns the directory provider
-/// that finds the location of the resource's containing folder on disk. The match is fuzzy so if a Swift Package
-/// Manager's resource bundle is in use it could take the shape of `PackageName_PackageName.bundle` in which case
-/// this function only needs `PackageName` as its input to find the path to the bundle.
-///
-/// This function also normalizes for tests so that resources can be found while under test. `Bundle.main` is different
-/// in an app context vs an XCTest context.
-/// - Parameter resourceDirectory: The name of the directory or bundle to search for embedded within the main bundle.
-/// - Returns: If found, returns the directory provider closure.
-private func embeddedResourceProvider(named resourceDirectory: String) -> DirectoryProvider? {
-    let fileManager = FileManager.default
-    var bundle = Bundle.main
-
-    if bundle.isXCTestRunner {
-        bundle = Bundle.allBundles
-            .first(where: { $0.bundlePath.components(separatedBy: "/").last!.contains("Tests.xctest") == true })!
-    }
-
-    guard
-        let foundBundleURL = try? fileManager
-            .contentsOfDirectory(at: bundle.bundleURL, includingPropertiesForKeys: nil)
-            .first(where: { $0.lastPathComponent.contains(resourceDirectory) })
-    else { return nil }
-
-    return { foundBundleURL }
-}
-
 public extension Language {
     var highlightsFileURL: URL? {
         guard let url = directoryProvider?() else { return nil }
@@ -131,17 +101,66 @@ public extension Language {
                 options: [.skipsHiddenFiles]
             )
 
+            return contents.first(where: { $0.lastPathComponent == filename })
+        }
+        catch {
+            return nil
+        }
+    }
+}
+
+extension Language {
+    /// For languages where the resources are embedded in the app's bundle, this function returns the directory provider
+    /// that finds the location of the resource's containing folder on disk. The match is fuzzy so if a Swift Package
+    /// Manager's resource bundle is in use it could take the shape of `PackageName_PackageName.bundle` in which case
+    /// this function only needs `PackageName` as its input to find the path to the bundle.
+    ///
+    /// This function also normalizes for tests so that resources can be found while under test. `Bundle.main` is different
+    /// in an app context vs an XCTest context.
+    /// - Parameter resourceDirectory: The name of the directory or bundle to search for embedded within the main bundle.
+    /// - Returns: If found, returns the directory provider closure.
+    static func embeddedResourceProvider(named resourceDirectory: String) -> Language.DirectoryProvider? {
+        let fileManager = FileManager.default
+        var bundle = Bundle.main
+
+        if bundle.isXCTestRunner {
+            bundle = Bundle.allBundles
+                .first(where: { $0.bundlePath.components(separatedBy: "/").last!.contains("Tests.xctest") == true })!
+        }
+
+        guard
+            let foundBundleURL = try? fileManager
+                .contentsOfDirectory(at: bundle.bundleURL, includingPropertiesForKeys: nil)
+                .first(where: { $0.lastPathComponent.contains(resourceDirectory) }),
+            let resourceDirURL = searchForFileExtension("scm", startingIn: foundBundleURL)
+        else { return nil }
+
+        return { resourceDirURL }
+    }
+
+    private static func searchForFileExtension(_ ext: String, startingIn directory: URL) -> URL? {
+        let fileManager = FileManager.default
+
+        do {
+            let contents = try fileManager.contentsOfDirectory(
+                at: directory,
+                includingPropertiesForKeys: [.nameKey, .isDirectoryKey],
+                options: [.skipsHiddenFiles]
+            )
+
             for item in contents {
                 var isDirectory: ObjCBool = false
                 fileManager.fileExists(atPath: item.path, isDirectory: &isDirectory)
 
-                if isDirectory.boolValue {
-                    if let foundURL = findFile(filename, in: item.standardizedFileURL) {
-                        return foundURL
+                if isDirectory.boolValue == false {
+                    if item.lastPathComponent.contains(ext) {
+                        var urlComponents = URLComponents(url: item, resolvingAgainstBaseURL: false)!
+                        urlComponents.path = (urlComponents.path as NSString).deletingLastPathComponent
+                        return urlComponents.url
                     }
                 } else {
-                    if item.lastPathComponent == filename {
-                        return item
+                    if let foundURL = searchForFileExtension(ext, startingIn: item.standardizedFileURL) {
+                        return foundURL
                     }
                 }
             }

--- a/Sources/SwiftTreeSitter/Language.swift
+++ b/Sources/SwiftTreeSitter/Language.swift
@@ -132,13 +132,13 @@ extension Language {
             let foundBundleURL = try? fileManager
                 .contentsOfDirectory(at: bundle.bundleURL, includingPropertiesForKeys: nil)
                 .first(where: { $0.lastPathComponent.contains(resourceDirectory) }),
-            let resourceDirURL = searchForFileExtension("scm", startingIn: foundBundleURL)
+            let resourceDirURL = searchForDirectoryContainingFileExtension("scm", startingIn: foundBundleURL)
         else { return nil }
 
         return { resourceDirURL }
     }
 
-    private static func searchForFileExtension(_ ext: String, startingIn directory: URL) -> URL? {
+    private static func searchForDirectoryContainingFileExtension(_ ext: String, startingIn directory: URL) -> URL? {
         let fileManager = FileManager.default
 
         do {
@@ -159,7 +159,7 @@ extension Language {
                         return urlComponents.url
                     }
                 } else {
-                    if let foundURL = searchForFileExtension(ext, startingIn: item.standardizedFileURL) {
+                    if let foundURL = searchForDirectoryContainingFileExtension(ext, startingIn: item.standardizedFileURL) {
                         return foundURL
                     }
                 }

--- a/Sources/SwiftTreeSitter/Language.swift
+++ b/Sources/SwiftTreeSitter/Language.swift
@@ -1,17 +1,19 @@
 import Foundation
 import tree_sitter
 
+/// This is a closure whose output URL is to the directory which has the language `scm` files in its hierarchy. The
+/// ultimate search is recursive; if the resource files are embedded within hierarchy
+/// `Resources.bundle/Contents/Resources/queries`, giving the path to `Resources.bundle` will result in the files
+/// being found.
+public typealias DirectoryProvider = () -> URL
+
 public struct Language {
     public var tsLanguage: UnsafePointer<TSLanguage>
+    public var directoryProvider: DirectoryProvider?
 
-    /// The topmost directory inside of the main bundle which will contain the scm resources for queries, highlights,
-    /// etc. This does not need to be the precise name of a Swift package's resource bundle and is often the name
-    /// of the Swift package vending resources (when used in a Swift Package Manager context).
-    public var resourceDirectory: String?
-
-    public init(language: UnsafePointer<TSLanguage>, resourceDirectory: String? = nil) {
+    public init(language: UnsafePointer<TSLanguage>, directoryProvider: DirectoryProvider? = nil) {
         self.tsLanguage = language
-        self.resourceDirectory = resourceDirectory
+        self.directoryProvider = directoryProvider
     }
 }
 
@@ -62,64 +64,79 @@ extension Language {
 }
 
 extension Language: Equatable {
+    public static func ==(lhs: Language, rhs: Language) -> Bool {
+        return lhs.tsLanguage == rhs.tsLanguage
+    }
+}
+
+/// For languages where the resources are embedded in the app's bundle, this function returns the directory provider
+/// that finds the location of the resource's containing folder on disk. The match is fuzzy so if a Swift Package
+/// Manager's resource bundle is in use it could take the shape of `PackageName_PackageName.bundle` in which case
+/// this function only needs `PackageName` as its input to find the path to the bundle.
+///
+/// This function also normalizes for tests so that resources can be found while under test. `Bundle.main` is different
+/// in an app context vs an XCTest context.
+/// - Parameter resourceDirectory: The name of the directory or bundle to search for embedded within the main bundle.
+/// - Returns: If found, returns the directory provider closure.
+public func embeddedResourceProvider(named resourceDirectory: String) -> DirectoryProvider? {
+    let fileManager = FileManager.default
+    var bundle = Bundle.main
+
+    if bundle.isXCTestRunner {
+        bundle = Bundle.allBundles
+            .first(where: { $0.bundlePath.components(separatedBy: "/").last!.contains("Tests.xctest") == true })!
+    }
+
+    guard
+        let foundBundleURL = try? fileManager
+            .contentsOfDirectory(at: bundle.bundleURL, includingPropertiesForKeys: nil)
+            .first(where: { $0.lastPathComponent.contains(resourceDirectory) })
+    else { return nil }
+
+    return { foundBundleURL }
 }
 
 public extension Language {
     var highlightsFileURL: URL? {
-        return searchForResource(named: "highlights")
+        guard let url = directoryProvider?() else { return nil }
+        return findFile("highlights.scm", in: url)
     }
 
     var injectionsFileURL: URL? {
-        return searchForResource(named: "injections")
+        guard let url = directoryProvider?() else { return nil }
+        return findFile("injections.scm", in: url)
     }
 
-    private func searchForResource(named name: String) -> URL? {
+    private func findFile(_ filename: String, in directory: URL) -> URL? {
         let fileManager = FileManager.default
-        var bundle = Bundle.main
 
-        func findFile(_ filename: String, in directory: URL) -> URL? {
-            do {
-                let contents = try fileManager.contentsOfDirectory(
-                    at: directory,
-                    includingPropertiesForKeys: [.nameKey, .isDirectoryKey],
-                    options: [.skipsHiddenFiles]
-                )
+        do {
+            let contents = try fileManager.contentsOfDirectory(
+                at: directory,
+                includingPropertiesForKeys: [.nameKey, .isDirectoryKey],
+                options: [.skipsHiddenFiles]
+            )
 
-                for item in contents {
-                    var isDirectory: ObjCBool = false
-                    fileManager.fileExists(atPath: item.path, isDirectory: &isDirectory)
+            for item in contents {
+                var isDirectory: ObjCBool = false
+                fileManager.fileExists(atPath: item.path, isDirectory: &isDirectory)
 
-                    if isDirectory.boolValue {
-                        if let foundURL = findFile(filename, in: item.standardizedFileURL) {
-                            return foundURL
-                        }
-                    } else {
-                        if item.lastPathComponent == filename {
-                            return item
-                        }
+                if isDirectory.boolValue {
+                    if let foundURL = findFile(filename, in: item.standardizedFileURL) {
+                        return foundURL
+                    }
+                } else {
+                    if item.lastPathComponent == filename {
+                        return item
                     }
                 }
             }
-            catch {
-                return nil
-            }
-
+        }
+        catch {
             return nil
         }
 
-        if bundle.isXCTestRunner {
-            bundle = Bundle.allBundles
-                .first(where: { $0.bundlePath.components(separatedBy: "/").last!.contains("Tests.xctest") == true })!
-        }
-
-        guard
-            let resourceDirectory,
-            let foundBundleURL = try? fileManager
-                .contentsOfDirectory(at: bundle.bundleURL, includingPropertiesForKeys: nil)
-                .first(where: { $0.lastPathComponent.contains(resourceDirectory) })
-        else { return nil }
-
-        return findFile("\(name).scm", in: foundBundleURL)
+        return nil
     }
 }
 

--- a/Sources/SwiftTreeSitter/Language.swift
+++ b/Sources/SwiftTreeSitter/Language.swift
@@ -18,6 +18,7 @@ public struct Language {
         self.directoryProvider = directoryProvider
     }
 
+    #if !os(WASI)
     /// Creates an instance.
     /// - Parameters:
     ///   - language: The language to parse.
@@ -26,6 +27,7 @@ public struct Language {
     public init(language: UnsafePointer<TSLanguage>, name: String) {
         self.init(language: language, directoryProvider: Language.embeddedResourceProvider(named: name))
     }
+    #endif
 }
 
 extension Language {
@@ -90,6 +92,7 @@ public extension Language {
     }
 }
 
+#if !os(WASI)
 extension Language {
     /// For languages where the resources are embedded in the app's bundle, this function returns the directory provider
     /// that finds the location of the resource's containing folder on disk. The match is fuzzy so if a Swift Package
@@ -161,8 +164,6 @@ private extension Bundle {
     }
 }
 
-
-#if !os(WASI)
 public extension Language {
     /// Construct a query object from data in a file.
     func query(contentsOf url: URL) throws -> Query {

--- a/Sources/SwiftTreeSitter/Language.swift
+++ b/Sources/SwiftTreeSitter/Language.swift
@@ -82,30 +82,11 @@ extension Language: Equatable {
 
 public extension Language {
     var highlightsFileURL: URL? {
-        guard let url = directoryProvider?() else { return nil }
-        return findFile("highlights.scm", in: url)
+        return directoryProvider?().appendingPathComponent("highlights.scm")
     }
 
     var injectionsFileURL: URL? {
-        guard let url = directoryProvider?() else { return nil }
-        return findFile("injections.scm", in: url)
-    }
-
-    private func findFile(_ filename: String, in directory: URL) -> URL? {
-        let fileManager = FileManager.default
-
-        do {
-            let contents = try fileManager.contentsOfDirectory(
-                at: directory,
-                includingPropertiesForKeys: [.nameKey, .isDirectoryKey],
-                options: [.skipsHiddenFiles]
-            )
-
-            return contents.first(where: { $0.lastPathComponent == filename })
-        }
-        catch {
-            return nil
-        }
+        return directoryProvider?().appendingPathComponent("injections.scm")
     }
 }
 

--- a/Sources/SwiftTreeSitter/Language.swift
+++ b/Sources/SwiftTreeSitter/Language.swift
@@ -114,7 +114,8 @@ extension Language {
 
         guard
             let foundBundleURL = try? fileManager
-                .contentsOfDirectory(at: bundle.bundleURL, includingPropertiesForKeys: nil)
+                .contentsOfDirectory(at: bundle.bundleURL, includingPropertiesForKeys: [.isDirectoryKey])
+                .filter({ (try? $0.resourceValues(forKeys: [.isDirectoryKey]).isDirectory) == true })
                 .first(where: { $0.lastPathComponent.contains(resourceDirectory) }),
             let resourceDirURL = searchForDirectoryContainingFileExtension("scm", startingIn: foundBundleURL)
         else { return nil }

--- a/Tests/SwiftTreeSitterTests/LanguageTests.swift
+++ b/Tests/SwiftTreeSitterTests/LanguageTests.swift
@@ -11,7 +11,10 @@ final class LanguageTests: XCTestCase {
         let bundlePath = "Swift.bundle/Contents/Resources/queries"
         try setupFile(filename, in: bundlePath)
 
-        let language = Language(language: tree_sitter_swift(), resourceDirectory: "Swift")
+        let language = Language(
+            language: tree_sitter_swift(),
+            directoryProvider: embeddedResourceProvider(named: "Swift")
+        )
         XCTAssertNotNil(language.highlightsFileURL)
 
         try removeFile(filename, in: bundlePath)
@@ -22,7 +25,10 @@ final class LanguageTests: XCTestCase {
         let dirPath = "Markdown/queries"
         try setupFile(filename, in: dirPath)
 
-        let language = Language(language: tree_sitter_swift(), resourceDirectory: "Markdown")
+        let language = Language(
+            language: tree_sitter_swift(),
+            directoryProvider: embeddedResourceProvider(named: "Markdown")
+        )
         XCTAssertNotNil(language.injectionsFileURL)
 
         try removeFile(filename, in: dirPath)
@@ -35,7 +41,10 @@ final class LanguageTests: XCTestCase {
         try setupFile(filename, in: jsonDirPath)
         try setupFile(filename, in: json5DirPath)
 
-        let language = Language(language: tree_sitter_swift(), resourceDirectory: "JSON")
+        let language = Language(
+            language: tree_sitter_swift(),
+            directoryProvider: embeddedResourceProvider(named: "JSON")
+        )
         XCTAssertNotNil(language.injectionsFileURL)
         XCTAssertTrue(language.injectionsFileURL!.absoluteString.contains("JSON/queries"))
 

--- a/Tests/SwiftTreeSitterTests/LanguageTests.swift
+++ b/Tests/SwiftTreeSitterTests/LanguageTests.swift
@@ -13,7 +13,7 @@ final class LanguageTests: XCTestCase {
 
         let language = Language(
             language: tree_sitter_swift(),
-            languageName: "Swift"
+            name: "Swift"
         )
         XCTAssertNotNil(language.highlightsFileURL)
 
@@ -27,7 +27,7 @@ final class LanguageTests: XCTestCase {
 
         let language = Language(
             language: tree_sitter_swift(),
-            languageName: "Markdown"
+            name: "Markdown"
         )
         XCTAssertNotNil(language.injectionsFileURL)
 
@@ -43,7 +43,7 @@ final class LanguageTests: XCTestCase {
 
         let language = Language(
             language: tree_sitter_swift(),
-            languageName: "JSON"
+            name: "JSON"
         )
         XCTAssertNotNil(language.injectionsFileURL)
         XCTAssertTrue(language.injectionsFileURL!.absoluteString.contains("JSON/queries"))

--- a/Tests/SwiftTreeSitterTests/LanguageTests.swift
+++ b/Tests/SwiftTreeSitterTests/LanguageTests.swift
@@ -28,6 +28,21 @@ final class LanguageTests: XCTestCase {
         try removeFile(filename, in: dirPath)
     }
 
+    func testMatchHappensWhenMultiplePathsShareCommonName() throws {
+        let filename = "injections.scm"
+        let jsonDirPath = "JSON/queries"
+        let json5DirPath = "JSON5/queries"
+        try setupFile(filename, in: jsonDirPath)
+        try setupFile(filename, in: json5DirPath)
+
+        let language = Language(language: tree_sitter_swift(), resourceDirectory: "JSON")
+        XCTAssertNotNil(language.injectionsFileURL)
+        XCTAssertTrue(language.injectionsFileURL!.absoluteString.contains("JSON/queries"))
+
+        try removeFile(filename, in: jsonDirPath)
+        try removeFile(filename, in: json5DirPath)
+    }
+
     private func setupFile(_ filename: String, in directoryPath: String) throws {
         let dir = Bundle.test.bundlePath.appending("/\(directoryPath)")
         let filePath = "\(dir)/\(filename)"

--- a/Tests/SwiftTreeSitterTests/LanguageTests.swift
+++ b/Tests/SwiftTreeSitterTests/LanguageTests.swift
@@ -1,3 +1,4 @@
+#if !os(WASI)
 import Foundation
 import TestTreeSitterSwift
 import SwiftTreeSitter
@@ -80,3 +81,4 @@ private extension Bundle {
             )!
     }
 }
+#endif

--- a/Tests/SwiftTreeSitterTests/LanguageTests.swift
+++ b/Tests/SwiftTreeSitterTests/LanguageTests.swift
@@ -1,0 +1,58 @@
+import Foundation
+import TestTreeSitterSwift
+import SwiftTreeSitter
+import XCTest
+
+final class LanguageTests: XCTestCase {
+    private let fileManager = FileManager.default
+
+    func testFileFoundInBundle() throws {
+        let filename = "highlights.scm"
+        let bundlePath = "Swift.bundle/Contents/Resources/queries"
+        try setupFile(filename, in: bundlePath)
+
+        let language = Language(language: tree_sitter_swift(), resourceDirectory: "Swift")
+        XCTAssertNotNil(language.highlightsFileURL)
+
+        try removeFile(filename, in: bundlePath)
+    }
+
+    func testFileFoundInResourceDir() throws {
+        let filename = "injections.scm"
+        let dirPath = "Markdown/queries"
+        try setupFile(filename, in: dirPath)
+
+        let language = Language(language: tree_sitter_swift(), resourceDirectory: "Markdown")
+        XCTAssertNotNil(language.injectionsFileURL)
+
+        try removeFile(filename, in: dirPath)
+    }
+
+    private func setupFile(_ filename: String, in directoryPath: String) throws {
+        let dir = Bundle.test.bundlePath.appending("/\(directoryPath)")
+        let filePath = "\(dir)/\(filename)"
+
+        if fileManager.fileExists(atPath: dir, isDirectory: nil) == false {
+            try fileManager.createDirectory(atPath: dir, withIntermediateDirectories: true)
+        }
+
+        if fileManager.createFile(atPath: filePath, contents: nil) == false {
+            XCTFail("could not write file")
+        }
+    }
+
+    private func removeFile(_ filename: String, in directoryPath: String) throws {
+        let filePath = Bundle.test.bundlePath.appending("/\(directoryPath)/\(filename)")
+        try fileManager.removeItem(atPath: filePath)
+    }
+}
+
+private extension Bundle {
+    static var test: Bundle {
+        return Bundle.allBundles
+            .first(where: { $0.bundlePath.components(separatedBy: "/")
+                .last!
+                .contains("Tests.xctest") == true }
+            )!
+    }
+}

--- a/Tests/SwiftTreeSitterTests/LanguageTests.swift
+++ b/Tests/SwiftTreeSitterTests/LanguageTests.swift
@@ -13,7 +13,7 @@ final class LanguageTests: XCTestCase {
 
         let language = Language(
             language: tree_sitter_swift(),
-            directoryProvider: embeddedResourceProvider(named: "Swift")
+            languageName: "Swift"
         )
         XCTAssertNotNil(language.highlightsFileURL)
 
@@ -27,7 +27,7 @@ final class LanguageTests: XCTestCase {
 
         let language = Language(
             language: tree_sitter_swift(),
-            directoryProvider: embeddedResourceProvider(named: "Markdown")
+            languageName: "Markdown"
         )
         XCTAssertNotNil(language.injectionsFileURL)
 
@@ -43,7 +43,7 @@ final class LanguageTests: XCTestCase {
 
         let language = Language(
             language: tree_sitter_swift(),
-            directoryProvider: embeddedResourceProvider(named: "JSON")
+            languageName: "JSON"
         )
         XCTAssertNotNil(language.injectionsFileURL)
         XCTAssertTrue(language.injectionsFileURL!.absoluteString.contains("JSON/queries"))


### PR DESCRIPTION
This PR adds support to a `Language` instance to be instantiated with either a closure that can return a `URL` pointing to the directory containing the `scm` assets for a language, or the language name which presumably would be used in the app's main bundle to hold the resources for that language (for example `TreeSitterSwift`'s package produces a `TreeSitterSwift_TreeSitterSwift.bundle` resource bundle which can be accessed by specifying `Swift` as the language name).

The goal here is to make easier grabbing the `highlights` and `injections` files for use with Tree Sitter queries.