### PR TITLE
Replace git submodule with package dependency for tree-sitter integration

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "tree-sitter"]
-	path = tree-sitter
-	url = https://github.com/tree-sitter/tree-sitter.git
 [submodule "tree-sitter-swift"]
 	path = tree-sitter-swift
 	url = https://github.com/alex-pinkus/tree-sitter-swift

--- a/Package.swift
+++ b/Package.swift
@@ -8,13 +8,6 @@ let settings: [SwiftSetting] = [
 
 let package = Package(
 	name: "SwiftTreeSitter",
-    platforms: [
-        .macOS(.v10_13),
-        .iOS(.v12),
-        .tvOS(.v12),
-        .macCatalyst(.v13),
-        .watchOS(.v4)
-    ],
 	products: [
 		.library(name: "SwiftTreeSitter", targets: ["SwiftTreeSitter"]),
 		.library(name: "SwiftTreeSitterLayer", targets: ["SwiftTreeSitterLayer"]),

--- a/Package.swift
+++ b/Package.swift
@@ -19,14 +19,10 @@ let package = Package(
 		.library(name: "SwiftTreeSitter", targets: ["SwiftTreeSitter"]),
 		.library(name: "SwiftTreeSitterLayer", targets: ["SwiftTreeSitterLayer"]),
 	],
+    dependencies: [
+        .package(url: "https://github.com/tree-sitter/tree-sitter", .upToNextMajor(from: "0.20.9")),
+    ],
 	targets: [
-		.target(
-			name: "tree-sitter",
-			path: "tree-sitter/lib",
-			sources: ["src/lib.c"],
-			publicHeadersPath: "include",
-			cSettings: [.headerSearchPath("src/")]
-		),
 		.target(
 			name: "TestTreeSitterSwift",
 			path: "tree-sitter-swift",
@@ -36,7 +32,9 @@ let package = Package(
 		),
 		.target(
 			name: "SwiftTreeSitter",
-			dependencies: ["tree-sitter"],
+			dependencies: [
+                .product(name: "TreeSitter", package: "tree-sitter"),
+            ],
 			swiftSettings: settings
 		),
 		.testTarget(

--- a/Package.swift
+++ b/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
 		.library(name: "SwiftTreeSitterLayer", targets: ["SwiftTreeSitterLayer"]),
 	],
     dependencies: [
-        .package(url: "https://github.com/tree-sitter/tree-sitter", .upToNextMajor(from: "0.20.9")),
+        .package(url: "https://github.com/tree-sitter/tree-sitter", .upToNextMinor(from: "0.20.9")),
     ],
 	targets: [
 		.target(

--- a/Sources/SwiftTreeSitter/Encoding+Helpers.swift
+++ b/Sources/SwiftTreeSitter/Encoding+Helpers.swift
@@ -1,5 +1,5 @@
 import Foundation
-import tree_sitter
+import TreeSitter
 
 extension String.Encoding {
     var internalEncoding: TSInputEncoding? {

--- a/Sources/SwiftTreeSitter/Input.swift
+++ b/Sources/SwiftTreeSitter/Input.swift
@@ -7,7 +7,7 @@
 //
 
 import Foundation
-import tree_sitter
+import TreeSitter
 
 final class Input {
     typealias Buffer = UnsafeMutableBufferPointer<Int8>

--- a/Sources/SwiftTreeSitter/InputEdit.swift
+++ b/Sources/SwiftTreeSitter/InputEdit.swift
@@ -1,5 +1,5 @@
 import Foundation
-import tree_sitter
+import TreeSitter
 
 /// Structure that describes a change to the text content.
 ///

--- a/Sources/SwiftTreeSitter/Language.swift
+++ b/Sources/SwiftTreeSitter/Language.swift
@@ -1,5 +1,5 @@
 import Foundation
-import tree_sitter
+import TreeSitter
 
 public struct Language: Sendable {
 	private let tsLanguagePointer: SendableUnsafePointer<TSLanguage>

--- a/Sources/SwiftTreeSitter/LanguageConfiguration.swift
+++ b/Sources/SwiftTreeSitter/LanguageConfiguration.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-import tree_sitter
+import TreeSitter
 
 /// A structure that holds a language name and its assoicated queries.
 public struct LanguageData: Sendable {

--- a/Sources/SwiftTreeSitter/Node.swift
+++ b/Sources/SwiftTreeSitter/Node.swift
@@ -7,7 +7,7 @@
 //
 
 import Foundation
-import tree_sitter
+import TreeSitter
 
 public struct Node {
     let internalNode: TSNode

--- a/Sources/SwiftTreeSitter/Parser.swift
+++ b/Sources/SwiftTreeSitter/Parser.swift
@@ -1,5 +1,5 @@
 import Foundation
-import tree_sitter
+import TreeSitter
 
 enum ParserError: Error {
     case languageIncompatible
@@ -54,7 +54,7 @@ extension Parser {
 			var count: UInt32 = 0
 			let tsRangePointer = ts_parser_included_ranges(internalParser, &count)
 
-			let tsRangeBuffer = UnsafeBufferPointer<tree_sitter.TSRange>(start: tsRangePointer, count: Int(count))
+			let tsRangeBuffer = UnsafeBufferPointer<TreeSitter.TSRange>(start: tsRangePointer, count: Int(count))
 
 			return tsRangeBuffer.map({ TSRange(internalRange: $0) })
 		}
@@ -64,7 +64,7 @@ extension Parser {
 			ranges.withUnsafeBytes { bufferPtr in
 				let count = newValue.count
 
-				guard let ptr = bufferPtr.baseAddress?.bindMemory(to: tree_sitter.TSRange.self, capacity: count) else {
+				guard let ptr = bufferPtr.baseAddress?.bindMemory(to: TreeSitter.TSRange.self, capacity: count) else {
 					preconditionFailure("unable to convert pointer")
 				}
 

--- a/Sources/SwiftTreeSitter/Point.swift
+++ b/Sources/SwiftTreeSitter/Point.swift
@@ -7,7 +7,7 @@
 //
 
 import Foundation
-import tree_sitter
+import TreeSitter
 
 public struct Point: Codable, Sendable {
     public let row: UInt32

--- a/Sources/SwiftTreeSitter/Predicate.swift
+++ b/Sources/SwiftTreeSitter/Predicate.swift
@@ -1,5 +1,5 @@
 import Foundation
-import tree_sitter
+import TreeSitter
 
 public enum QueryPredicateStep: Hashable, Sendable {
     case done

--- a/Sources/SwiftTreeSitter/Query.swift
+++ b/Sources/SwiftTreeSitter/Query.swift
@@ -1,5 +1,5 @@
 import Foundation
-import tree_sitter
+import TreeSitter
 
 public enum QueryError: Error {
     case none

--- a/Sources/SwiftTreeSitter/TSRange.swift
+++ b/Sources/SwiftTreeSitter/TSRange.swift
@@ -1,5 +1,5 @@
 import Foundation
-import tree_sitter
+import TreeSitter
 
 public struct TSRange: Codable, Hashable, Sendable {
     public let points: Range<Point>
@@ -10,12 +10,12 @@ public struct TSRange: Codable, Hashable, Sendable {
         self.bytes = bytes
     }
 
-    init(internalRange range: tree_sitter.TSRange) {
+    init(internalRange range: TreeSitter.TSRange) {
         self.bytes = range.start_byte..<range.end_byte
         self.points = Point(internalPoint: range.start_point)..<Point(internalPoint: range.end_point)
     }
 
-    init(potentiallyInvalidRange range: tree_sitter.TSRange) {
+    init(potentiallyInvalidRange range: TreeSitter.TSRange) {
         self.bytes = range.start_byte..<range.end_byte
 
         let start = Point(internalPoint: range.start_point)
@@ -25,7 +25,7 @@ public struct TSRange: Codable, Hashable, Sendable {
         self.points = start..<safeEnd
     }
 
-	var internalRange: tree_sitter.TSRange {
+	var internalRange: TreeSitter.TSRange {
 		return .init(start_point: points.lowerBound.internalPoint,
 					 end_point: points.upperBound.internalPoint,
 					 start_byte: bytes.lowerBound,

--- a/Sources/SwiftTreeSitter/Tree.swift
+++ b/Sources/SwiftTreeSitter/Tree.swift
@@ -1,4 +1,4 @@
-import tree_sitter
+import TreeSitter
 
 /// An immutable tree-sitter tree structure.
 public final class Tree: Sendable {

--- a/Sources/SwiftTreeSitter/TreeCursor.swift
+++ b/Sources/SwiftTreeSitter/TreeCursor.swift
@@ -1,5 +1,5 @@
 import Foundation
-import tree_sitter
+import TreeSitter
 
 public class TreeCursor {
     private var internalCursor: TSTreeCursor


### PR DESCRIPTION
Some of the dependencies of my project (like [Runestone](https://github.com/simonbs/Runestone)) rely on the tree-sitter project directly, which leads to conflicts due to duplicated symbols. This PR tries to fix this by replacing the tree-sitter git submodule with a Swift package dependency.

Note that the `tree-sitter-swift` submodule remains unchanged in this PR because it is currently used only for testing purposes, and altering it would introduce unnecessary dependencies.