### PR TITLE
Hotfix alloc crash, when no read data avail.

### DIFF
--- a/Sources/SwiftTreeSitter/Input.swift
+++ b/Sources/SwiftTreeSitter/Input.swift
@@ -50,14 +50,17 @@ private func readFunction(payload: UnsafeMutableRawPointer?, byteIndex: UInt32, 
     // get our self reference
     let wrapper: Input = Unmanaged.fromOpaque(payload!).takeUnretainedValue()
 
-    // call our Swift-friendly reader block
-    guard let data = wrapper.readBlock(Int(byteIndex), Point(internalPoint: position)) else {
-        bytesRead?.pointee = 0
-        return nil
+    // call our Swift-friendly reader block, or early out if there's no data to copy.
+    guard let data = wrapper.readBlock(Int(byteIndex), Point(internalPoint: position)),
+          data.count > 0
+    else
+    {
+      bytesRead?.pointee = 0
+      return nil
     }
 
     // copy the data into an internally-managed buffer with a lifetime of wrapper
-	let buffer = Input.Buffer.allocate(capacity: data.count)
+	  let buffer = Input.Buffer.allocate(capacity: data.count)
     let copiedLength = data.copyBytes(to: buffer)
     precondition(copiedLength == data.count)
 


### PR DESCRIPTION
> [!NOTE]
> This fixes a Swift **memory allocation crash**, when attempting to allocate an internally managed buffer with a capacity of **_0 (zero)_**, if there's no read data available for the data copy we early out and return `nil`.

**Backtrace**

```swift
Thread 1 Crashed::  Dispatch queue: CosmoEditor.TreeSitter.EditQueue
0   libswiftCore.dylib                       0x1ad1eeb74 swift_slowAlloc.cold.1 + 16
1   libswiftCore.dylib                       0x1ad12d500 swift_slowAlloc + 88
2   libswiftCore.dylib                       0x1ad06da1c static UnsafeMutableBufferPointer.allocate(capacity:) + 124
3   Kraken                                   0x109a4d098 readFunction(payload:byteIndex:position:bytesRead:) + 596 (Input.swift:60)
4   Kraken                                   0x109a4cd74 @objc readFunction(payload:byteIndex:position:bytesRead:) + 40
5   Kraken                                   0x10af42f64 ts_lexer__get_chunk + 76 (lexer.c:59)
6   Kraken                                   0x10af5cf18 ts_lexer__do_advance + 548 (lexer.c:195)
7   Kraken                                   0x10af42518 ts_lexer__advance + 508 (lexer.c:217)
8   Kraken                                   0x10b201e24 ts_lex + 60
9   Kraken                                   0x10af5e3bc ts_parser__lex + 1224 (parser.c:485)
10  Kraken                                   0x10af4823c ts_parser__advance + 340 (parser.c:1441)
11  Kraken                                   0x10af477bc ts_parser_parse + 1384 (parser.c:1933)
12  Kraken                                   0x109a58028 Parser.parse(tree:encoding:readBlock:) + 368 (Parser.swift:116)
13  Kraken                                   0x100939ebc TreeSitterState.parseDocument(readCallback:readBlock:) + 484 (TreeSitterState.swift:94)
14  Kraken                                   0x100939504 TreeSitterState.init(codeLanguage:readCallback:readBlock:) + 296 (TreeSitterState.swift:52)
15  Kraken                                   0x1009393cc TreeSitterState.__allocating_init(codeLanguage:readCallback:readBlock:) + 88
16  Kraken                                   0x100935c3c closure #1 in TreeSitterClient.setState(language:readCallback:readBlock:) + 364 (TreeSitterClient.swift:145)
17  Kraken                                   0x100936430 closure #1 in TreeSitterClient.performAsync(_:) + 996 
```

**LLDB Breakpoint**
```swift
Process 88310 stopped
* thread #3, queue = 'CosmoEditor.TreeSitter.EditQueue', stop reason = EXC_BREAKPOINT (code=1, subcode=0x1ad1eeb74)
    frame #0: 0x00000001ad1eeb74 libswiftCore.dylib`swift_slowAlloc.cold.1 + 16
libswiftCore.dylib`swift_slowAlloc.cold.1:
->  0x1ad1eeb74 <+16>: brk    #0x1

libswiftCore.dylib`swift_allocBox.cold.1:
    0x1ad1eeb78 <+0>:  adrp   x8, 186
    0x1ad1eeb7c <+4>:  add    x8, x8, #0x8f0            ; "Could not allocate memory."
    0x1ad1eeb80 <+8>:  adrp   x9, 359303
```