### PR TITLE
Fix README formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ A very common use of tree-sitter is to do syntax highlighting. It is possible to
 
 First, check out how it works with SwiftTreeSitterLayer. It's complex, but does a lot for you.
 
-```swift
+````swift
 // LanguageConfiguration takes care of finding and loading queries in SPM-created bundles.
 let markdownConfig = try LanguageConfiguration(tree_sitter_markdown(), name: "Markdown")
 let markdownInlineConfig = try LanguageConfiguration(
@@ -148,7 +148,7 @@ let highlights = try rootLayer.highlights(in: fullRange, provider: textProvider)
 for namedRange in highlights {
     print("\(namedRange.name): \(namedRange.range)")
 }
-```
+````
 
 You can also use SwiftTreeSitter directly:
 


### PR DESCRIPTION
The README parsing was getting a bit confused with the nested code blocks, this should fix that.

|before|after|
|-|-|
|<img width="820" alt="Screenshot 2024-05-20 at 11 30 17 PM" src="https://github.com/ChimeHQ/SwiftTreeSitter/assets/483/6251e107-05c4-4f8f-9217-0a7b3c1ff435">|<img width="798" alt="Screenshot 2024-05-20 at 11 30 22 PM" src="https://github.com/ChimeHQ/SwiftTreeSitter/assets/483/16e6e60e-42ca-40f2-b6e9-c3ccaecca49f">|
