### PR TITLE
export tree sitter's id field

### DIFF
--- a/Sources/SwiftTreeSitter/Node.swift
+++ b/Sources/SwiftTreeSitter/Node.swift
@@ -37,6 +37,12 @@ extension Node: Equatable {
     }
 }
 
+extension Node: Hashable {
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(internalNode.id.hashValue)
+    }
+}
+
 extension Node {
     public var sExpressionString: String? {
         guard let str = ts_node_string(internalNode) else {

--- a/Sources/SwiftTreeSitter/Node.swift
+++ b/Sources/SwiftTreeSitter/Node.swift
@@ -37,12 +37,6 @@ extension Node: Equatable {
     }
 }
 
-extension Node: Hashable {
-    public func hash(into hasher: inout Hasher) {
-        hasher.combine(internalNode.id.hashValue)
-    }
-}
-
 extension Node {
     public var sExpressionString: String? {
         guard let str = ts_node_string(internalNode) else {
@@ -62,6 +56,10 @@ extension Node {
         }
 
         return String(cString: str)
+    }
+
+    public var id: UInt {
+        return UInt(bitPattern: internalNode.id)
     }
 
     public var symbol: Int {


### PR DESCRIPTION
This PR exports the underlying tree_node's `id` field as `UInt`.

There were two choices to make: one is to export the id, the other is to make a Node hashable based on the id. Investigation shows it's the least confusion solution to export the `id` field. Details see #26 