### PR TITLE
LanguageConfiguration fails to load in Unit Tests

### DIFF
--- a/Sources/SwiftTreeSitter/LanguageConfiguration.swift
+++ b/Sources/SwiftTreeSitter/LanguageConfiguration.swift
@@ -127,7 +127,7 @@ extension LanguageConfiguration {
         return bundlePath?.appendingPathComponent("queries", isDirectory: true)
 #else
 		// Linux and Windows use .resources instead of .bundle
-		let bundlePath = Bundle.main.url(forResource: bundleName, withExtension: "resources")
+		let resourcePath = Bundle.main.url(forResource: bundleName, withExtension: "resources")
 		return resourcePath?.appendingPathComponent("queries", isDirectory: true)
 #endif
 	}

--- a/Sources/SwiftTreeSitter/LanguageConfiguration.swift
+++ b/Sources/SwiftTreeSitter/LanguageConfiguration.swift
@@ -109,21 +109,9 @@ extension LanguageConfiguration {
 }
 
 extension LanguageConfiguration {
-	static let bundleContainerURL: URL? = {
-		let mainBundle = Bundle.main
-
-		guard mainBundle.isXCTestRunner else {
-			return mainBundle.resourceURL
-		}
-
-		// we have to go up one directory, because Xcode puts SPM dependency bundles
-		return Bundle.testBundle?.bundleURL.deletingLastPathComponent()
-	}()
-
 	static func bundleQueriesDirectoryURL(for bundleName: String) -> URL? {
 #if os(macOS) || targetEnvironment(macCatalyst)
-		let bundlePath = bundleContainerURL?.appendingPathComponent("\(bundleName).bundle", isDirectory: true)
-		
+		let bundlePath = Bundle.main.url(forResource: bundleName, withExtension: "bundle")
 		guard let bundlePath else { return nil }
 		
 		// Depending on how you compile a macOS executable, this path varies.
@@ -135,13 +123,11 @@ extension LanguageConfiguration {
 		}
 		return bundlePath.appendingPathComponent("Contents/Resources/queries", isDirectory: true)
 #elseif os(iOS) || os(tvOS) || os(visionOS) || os(watchOS)
-		let bundlePath = bundleContainerURL?.appendingPathComponent("\(bundleName).bundle", isDirectory: true)
-		
+		let bundlePath = Bundle.main.url(forResource: bundleName, withExtension: "bundle")
         return bundlePath?.appendingPathComponent("queries", isDirectory: true)
 #else
 		// Linux and Windows use .resources instead of .bundle
-		let resourcePath = bundleContainerURL?.appendingPathComponent("\(bundleName).resources", isDirectory: true)
-		
+		let bundlePath = Bundle.main.url(forResource: bundleName, withExtension: "resources")
 		return resourcePath?.appendingPathComponent("queries", isDirectory: true)
 #endif
 	}


### PR DESCRIPTION
This PR fixes an issue where the language bundle could not be located when running XCTest on iOS and macOS.

The change was validated by building on macOS Sequoia 15.7 using Xcode 26.2 and running the following checks:

- ✅ Unit tests on the iOS 17 simulator
- ✅ Unit tests on macOS Sequoia 15.7
- ✅ SwiftTreeSitterExample sample app on macOS Sequoia 15.7
- ❌ Linux and Windows have not been tested.

https://github.com/tree-sitter/swift-tree-sitter/issues/44