### PR TITLE
Make incremental parsing APIs public (applyEdit, parse with affected set)

### DIFF
--- a/Sources/SwiftTreeSitterLayer/LanguageLayer.swift
+++ b/Sources/SwiftTreeSitterLayer/LanguageLayer.swift
@@ -174,7 +174,7 @@ extension LanguageLayer {
 	}
 
 	private func parse(with content: Content, affecting affectedSet: IndexSet, resolveSublayers resolve: Bool) -> IndexSet {
-		// afer this completes, affectedSet is valid again
+		// after this completes, affectedSet is valid again
 		var set = parse(with: content)
 
 		set.formUnion(affectedSet)

--- a/Sources/SwiftTreeSitterLayer/LanguageLayer.swift
+++ b/Sources/SwiftTreeSitterLayer/LanguageLayer.swift
@@ -142,7 +142,7 @@ extension LanguageLayer {
 }
 
 extension LanguageLayer {
-	private func applyEdit(_ edit: InputEdit) {
+	public func applyEdit(_ edit: InputEdit) {
 		state.applyEdit(edit)
 
 		// and now update the included ranges
@@ -173,7 +173,7 @@ extension LanguageLayer {
 		return invalidations
 	}
 
-	private func parse(with content: Content, affecting affectedSet: IndexSet, resolveSublayers resolve: Bool) -> IndexSet {
+	public func parse(with content: Content, affecting affectedSet: IndexSet, resolveSublayers resolve: Bool) -> IndexSet {
 		// after this completes, affectedSet is valid again
 		var set = parse(with: content)
 


### PR DESCRIPTION
Hi, thank you for maintaining this package.

This PR just makes two methods in LanguageLayer public.


## Summary
- Expose incremental parsing entrypoints to allow external clients to keep LanguageLayer state in sync with edits.
- Provide a parse API that accepts an affected range set and an explicit sublayer-resolution flag.

## Motivation
My [CotEditor](github.com/coteditor/CotEditor) (and similar clients) track text edits incrementally and want to:
- apply Input​Edit without immediately resolving sublayers
- parse highlights using a minimal affected range
- explicitly control when to resolve injection sublayers for performance

These are currently possible only with internal APIs.

## Changes
- Make Language​Layer​.apply​Edit(_:) public.
- Make Language​Layer​.parse(with​:affecting​:resolve​Sublayers:) public.
- Fix a trivial typo in comment.

## Notes
- No behavior changes to existing internal logic; this only exposes existing functionality.
- resolve​Sublayers remains explicit to allow callers to trade accuracy vs. latency.
- Intended for advanced clients; simple use-cases should continue using did​Change​Content.

## Testing
- Existing tests pass (no behavior change).
- Verified in CotEditor integration.
