### PR TITLE
Support custom query definitions in grammar queries

### DIFF
--- a/Sources/SwiftTreeSitter/LanguageConfiguration.swift
+++ b/Sources/SwiftTreeSitter/LanguageConfiguration.swift
@@ -156,7 +156,7 @@ extension Query {
 			guard fileURL.pathExtension == "scm" else {
 				continue
 			}
-			guard FileManager.default.isReadableFile(atPath: fileURL.path) else {
+			guard try fileURL.resourceValues(forKeys: [.isReadableKey]).isReadable == true else {
 				continue
 			}
 			

--- a/Sources/SwiftTreeSitter/LanguageConfiguration.swift
+++ b/Sources/SwiftTreeSitter/LanguageConfiguration.swift
@@ -145,20 +145,41 @@ extension Query {
 	}
 
 	static func queries(for language: Language, in url: URL) throws -> [Query.Definition: Query] {
+		guard let enumerator = FileManager.default.enumerator(at: url,
+															  includingPropertiesForKeys: [.isReadableKey],
+															  options: [.skipsHiddenFiles]) else {
+			return [:]
+		}
+		
 		var queries = [Query.Definition: Query]()
-
-		if let query = try Self.query(definition: .injections, for: language, in: url) {
-			queries[.injections] = query
+		for case let fileURL as URL in enumerator {
+			guard fileURL.pathExtension == "scm" else {
+				continue
+			}
+			guard FileManager.default.isReadableFile(atPath: fileURL.path) else {
+				continue
+			}
+			
+			let query = try Query(language: language, url: fileURL)
+			let definition: Query.Definition
+			switch fileURL.lastPathComponent {
+			case Query.Definition.injections.filename:
+				definition = .injections
+				
+			case Query.Definition.highlights.filename:
+				definition = .highlights
+				
+			case Query.Definition.locals.filename:
+				definition = .locals
+				
+			default:
+				let filename = fileURL.lastPathComponent.replacingOccurrences(of: ".scm", with: "")
+				definition = .custom(filename)
+			}
+			
+			queries[definition] = query
 		}
-
-		if let query = try Self.query(definition: .highlights, for: language, in: url) {
-			queries[.highlights] = query
-		}
-
-		if let query = try Self.query(definition: .locals, for: language, in: url) {
-			queries[.locals] = query
-		}
-
+		
 		return queries
 	}
 }


### PR DESCRIPTION
This PR extends query loading to support custom Tree-sitter query definitions beyond the built-in ones (highlights, locals, injections).

Previously, only predefined query types were loaded. This change allows additional .scm files (e.g. folds.scm, indents.scm, textobjects.scm) to be recognized as Query.Definition.custom(name).

This makes the system more flexible and compatible with grammars that define additional query types.