### PR TITLE
fix: fall back to bundle search when running under XCTest

### DIFF
--- a/Sources/SwiftTreeSitter/LanguageConfiguration.swift
+++ b/Sources/SwiftTreeSitter/LanguageConfiguration.swift
@@ -110,6 +110,22 @@ extension LanguageConfiguration {
 
 extension LanguageConfiguration {
 	static func bundleQueriesDirectoryURL(for bundleName: String) -> URL? {
+#if DEBUG
+		if ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] != nil {
+			let bundles = Bundle.allBundles + Bundle.allFrameworks
+			
+			for bundle in bundles {
+				if let bundlePath = bundle.url(forResource: bundleName, withExtension: "bundle") {
+					let short = bundlePath.appendingPathComponent("queries", isDirectory: true)
+					if FileManager.default.fileExists(atPath: short.path) {
+						return short
+					}
+					return bundlePath.appendingPathComponent("Contents/Resources/queries", isDirectory: true)
+				}
+			}
+		}
+#endif
+		
 #if os(macOS) || targetEnvironment(macCatalyst)
 		let bundlePath = Bundle.main.url(forResource: bundleName, withExtension: "bundle")
 		guard let bundlePath else { return nil }


### PR DESCRIPTION
# Background

`bundleQueriesDirectoryURL(for:)` currently looks up grammar resource bundles using `Bundle.main`.

This works correctly for applications, where the grammar bundles are embedded in the main application bundle. However, when running unit tests, `Bundle.main` refers to the XCTest runner instead of the application bundle, so the grammar resource bundles cannot always be located even though they are present in the test process.

As a result, loading query files (e.g. queries/highlights.scm) may fail during unit tests.

# Proposed change

When running under XCTest (detected via the XCTestConfigurationFilePath environment variable), perform a fallback search through `Bundle.allBundles` and `Bundle.allFrameworks` to locate the requested resource bundle.