### PR TITLE
perf: cache query capture names

### DIFF
--- a/Sources/SwiftTreeSitter/Query.swift
+++ b/Sources/SwiftTreeSitter/Query.swift
@@ -1,6 +1,15 @@
 import Foundation
 import TreeSitter
 
+/// Stores a query capture name together with its parsed hierarchy.
+private struct CachedCaptureName: Sendable {
+    /// The complete capture name returned by Tree-sitter.
+    let value: String
+
+    /// The hierarchy used by highlighting and injection consumers.
+    let components: [String]
+}
+
 public enum QueryError: Error {
     case none
     case syntax(UInt32)
@@ -46,6 +55,9 @@ public final class Query: Sendable {
     let internalQueryPointer: SendableOpaquePointer
     let predicateList: [[Predicate]]
 
+    /// Keeps capture names out of the cursor's per-capture hot path.
+    private let captureNames: [CachedCaptureName?]
+
     /// Construct a query object from scm data
     ///
     /// This operation has do to a lot of work, especially if any
@@ -74,6 +86,18 @@ public final class Query: Sendable {
 
         self.internalQueryPointer = SendableOpaquePointer(queryPtr)
         self.predicateList = try PredicateParser().predicates(in: queryPtr)
+        self.captureNames = (0..<Int(ts_query_capture_count(queryPtr))).map { id in
+            var length: UInt32 = 0
+            guard let value = ts_query_capture_name_for_id(queryPtr, UInt32(id), &length) else {
+                return nil
+            }
+
+            let name = String(cString: value)
+            return CachedCaptureName(
+                value: name,
+                components: name.components(separatedBy: ".")
+            )
+        }
     }
 
 	/// Construct a query object from scm data located at a url
@@ -137,13 +161,23 @@ public final class Query: Sendable {
 	}
 
     public func captureName(for id: Int) -> String? {
-        var length: UInt32 = 0
-
-        guard let cStr = ts_query_capture_name_for_id(internalQuery, UInt32(id), &length) else {
+        guard captureNames.indices.contains(id) else {
             return nil
         }
 
-        return String(cString: cStr)
+        return captureNames[id]?.value
+    }
+
+    /// Returns the cached name and hierarchy for a capture identifier.
+    ///
+    /// - Parameter id: The Tree-sitter capture identifier.
+    /// - Returns: The cached capture name when the identifier is valid.
+    fileprivate func cachedCaptureName(for id: Int) -> CachedCaptureName? {
+        guard captureNames.indices.contains(id) else {
+            return nil
+        }
+
+        return captureNames[id]
     }
 
     public func stringName(for id: Int) -> String? {
@@ -181,27 +215,27 @@ public struct QueryCapture {
 	/// The language injection depth.
 	public let depth: Int
 
-	init?(tsCapture: TSQueryCapture, internalTree: Tree, name: String?, patternIndex: Int, metadata: [String: String], depth: Int) {
+	init?(tsCapture: TSQueryCapture, internalTree: Tree, nameComponents: [String], patternIndex: Int, metadata: [String: String], depth: Int) {
 		guard let node = Node(internalNode: tsCapture.node, internalTree: internalTree) else {
             return nil
         }
 
         self.node = node
         self.index = Int(tsCapture.index)
-        self.nameComponents = name?.components(separatedBy: ".") ?? []
+        self.nameComponents = nameComponents
         self.patternIndex = patternIndex
 		self.metadata = metadata
 		self.depth = depth
     }
 
 	init?(tsCapture: TSQueryCapture, internalTree: Tree, query: Query?, patternIndex: Int, depth: Int) {
-		let name = query?.captureName(for: Int(tsCapture.index))
+		let captureName = query?.cachedCaptureName(for: Int(tsCapture.index))
 
 		let predicates = query?.predicates(for: patternIndex) ?? []
 
-		let metadata = name.map { QueryCapture.evaluateDirectives(predicates, with: $0) } ?? [:]
+		let metadata = captureName.map { QueryCapture.evaluateDirectives(predicates, with: $0.value) } ?? [:]
 
-		self.init(tsCapture: tsCapture, internalTree: internalTree, name: name, patternIndex: patternIndex, metadata: metadata, depth: depth)
+		self.init(tsCapture: tsCapture, internalTree: internalTree, nameComponents: captureName?.components ?? [], patternIndex: patternIndex, metadata: metadata, depth: depth)
 	}
 
 	private static func evaluateDirectives(_ predicates: [Predicate], with name: String) -> [String: String] {

--- a/Tests/SwiftTreeSitterTests/QueryTests.swift
+++ b/Tests/SwiftTreeSitterTests/QueryTests.swift
@@ -73,6 +73,10 @@ func main() {
 """
 		let queryData = try XCTUnwrap(queryText.data(using: .utf8))
 		let query = try Query(language: language, data: queryData)
+		let captureNames = (0..<query.captureCount).compactMap(query.captureName(for:))
+
+		XCTAssertEqual(captureNames, ["a", "a.b.c", "a.b"])
+		XCTAssertNil(query.captureName(for: query.captureCount))
 
 		let text = """
 func main() {


### PR DESCRIPTION
## Summary

- Cache every capture name when a query is initialized.
- Parse dotted capture-name components once and reuse them for every cursor result.
- Preserve public capture-name lookup behavior and directive metadata.
- Cover cached lookup and out-of-range behavior in the query tests.

## Motivation

Query cursors currently call the Tree-sitter C API and split the same dotted name for every emitted capture. Highlight queries can emit tens of thousands of captures from one compiled query, so this repeated immutable work dominates cursor materialization.

The cache moves that work into query initialization. Query objects are immutable and Sendable, which makes the cached values safe to share across cursor executions.

## Performance

The Rork Highlighter comparison harness measured the same 256 KiB Swift fixture on the same Apple Silicon machine with 20 samples. The benchmark performs parsing, highlight-query execution, predicate resolution, and semantic span materialization.

| Dependency | Median wall time |
| --- | ---: |
| swift-tree-sitter 0.25.0 | 75.63 ms |
| This change | 53.15 ms |

The end-to-end median is 29.7% lower. The benchmark returns more than 63,000 semantic captures per iteration.

## Validation

- swift test
- swift build -Xswiftc -warnings-as-errors